### PR TITLE
Add close methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sockets"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["scratchyone <scratchywon@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -14,11 +14,11 @@ description = "A WASM-only websocket library"
 repository = "https://github.com/scratchyone/wasm-sockets"
 readme = "Readme.md"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [package.metadata.docs.rs]
 targets = ["wasm32-unknown-unknown"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,24 @@ impl PollingClient {
     pub fn send_binary(&self, message: Vec<u8>) -> Result<(), JsValue> {
         self.event_client.send_binary(message)
     }
+
+    /// Close the connection
+    /// ```
+    /// client.close()?;
+    /// ```
+    pub fn close(&self) -> Result<(), JsValue> {
+        self.event_client.close()
+    }
+    /// Close the connection with a custom close code and, optionally, a reason string
+    ///
+    /// The reason string must be at most 123 bytes long.
+    ///
+    /// ```
+    /// client.close_with(1001, Some("going away"))?;
+    /// ```
+    pub fn close_with(&self, code: u16, reason: Option<&str>) -> Result<(), JsValue> {
+        self.event_client.close_with(code, reason)
+    }
 }
 
 #[derive(Debug, Clone, Error)]
@@ -434,5 +452,29 @@ impl EventClient {
         self.connection
             .borrow()
             .send_with_u8_array(message.as_slice())
+    }
+
+    /// Close the connection
+    /// ```
+    /// client.close()?;
+    /// ```
+    pub fn close(&self) -> Result<(), JsValue> {
+        self.connection.borrow().close()
+    }
+    /// Close the connection with a custom close code and, optionally, a reason string
+    ///
+    /// The reason string must be at most 123 bytes long.
+    ///
+    /// ```
+    /// client.close_with(1001, Some("going away"))?;
+    /// ```
+    pub fn close_with(&self, code: u16, reason: Option<&str>) -> Result<(), JsValue> {
+        match reason {
+            Some(reason) => self
+                .connection
+                .borrow()
+                .close_with_code_and_reason(code, reason),
+            None => self.connection.borrow().close_with_code(code),
+        }
     }
 }


### PR DESCRIPTION
Allows consumers to close the WebSocket.

I wonder if this should be the default behaviour when dropping the client?